### PR TITLE
Fix test + build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        architecture: x64
+    - name: Build
+      env:
+        JAVA_OPTS: -Xms512m -Xmx1024m
+      run: ./gradlew clean build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
 
+    env:
+      JAVA_OPTS: -Xms512m -Xmx1024m
+
     runs-on: ubuntu-latest
 
     steps:
@@ -20,7 +23,10 @@ jobs:
       with:
         java-version: 1.8
         architecture: x64
+    - name: Install local dependencies
+      run: |
+        cd .. ; git clone https://github.com/arrow-kt/arrow-meta.git
+        cd arrow-meta
+        ./gradlew publishMeta
     - name: Build
-      env:
-        JAVA_OPTS: -Xms512m -Xmx1024m
       run: ./gradlew clean build

--- a/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
+++ b/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
@@ -1,0 +1,8 @@
+// TODO: It doesn't support a composite package
+package singlepackage
+
+import arrow.*
+import arrowx.*
+fun <A> given(evidence: @Given A = arrow.given): A = evidence
+@Given val x = "yes!"
+val result = given<String>()

--- a/src/test/kotlin/arrow/proofs/typeclasses/GivenTests.kt
+++ b/src/test/kotlin/arrow/proofs/typeclasses/GivenTests.kt
@@ -1,17 +1,15 @@
-package arrow.proofs.typeclasses
+// TODO: It doesn't support a composite package
+package singlepackage
 
-import arrow.Given
 import org.junit.Test
 
 class GivenTest {
 
-    fun <A> given(evidence: @Given A = arrow.given): A =
-        evidence
-    @Given val x = "yes!"
+    // Arrow Meta Compiler Plugin is just applied during production code compilation (src/main/kotlin).
+    // Following best practices, tests just check the production code without including it.
 
     @Test
     fun `coherent polymorphic identity`() {
-        val result = given<String>()
         assert(result == "yes!")
     }
 }


### PR DESCRIPTION
This pull request re-organizes the source code:
- Production code in `GivenTest` has been moved to `src/main/kotlin`.
- `GivenTest` just checks the result.

## A different problem was found

This example shows **a limitation with the current implementation**: it seems it's not possible to use a composite package. For instance, it fails with `package arrow.proofs` or `package arrow.proofs.typeclasses`.