### PR TITLE
Rename prelude dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,7 @@ jobs:
         architecture: x64
     - name: Install local dependencies
       run: |
+        echo "This playground can be run from Intellij IDEA with testing purposes so it uses local dependencies"
         cd .. ; git clone https://github.com/arrow-kt/arrow-meta.git
         cd arrow-meta
         ./gradlew publishMeta

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    compile "io.arrow-kt:prelude:$ARROW_META_VERSION"
+    compile "io.arrow-kt:arrow-meta-prelude:$ARROW_META_VERSION"
     compile "io.arrow-kt:arrow-core-data:$ARROW_VERSION"
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }


### PR DESCRIPTION
Reason: https://github.com/arrow-kt/arrow-meta/pull/587