### PR TITLE
Remove comment from #2

### DIFF
--- a/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
+++ b/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
@@ -1,8 +1,0 @@
-// TODO: It doesn't support a composite package
-package singlepackage
-
-import arrow.*
-import arrowx.*
-fun <A> given(evidence: @Given A = arrow.given): A = evidence
-@Given val x = "yes!"
-val result = given<String>()

--- a/src/test/kotlin/arrow/proofs/typeclasses/GivenTests.kt
+++ b/src/test/kotlin/arrow/proofs/typeclasses/GivenTests.kt
@@ -1,12 +1,14 @@
 // TODO: It doesn't support a composite package
 package singlepackage
 
+import arrow.*
 import org.junit.Test
 
-class GivenTest {
+fun <A> given(evidence: @Given A = arrow.given): A = evidence
+@Given val x = "yes!"
+val result = given<String>()
 
-    // Arrow Meta Compiler Plugin is just applied during production code compilation (src/main/kotlin).
-    // Following best practices, tests just check the production code without including it.
+class GivenTest {
 
     @Test
     fun `coherent polymorphic identity`() {


### PR DESCRIPTION
**Arrow Meta Compiler Plugin** is being applied on production and testing code via **Arrow Meta Gradle Plugin** because `org.jetbrains.kotlin.gradle.tasks.KotlinCompile` includes both `compileKotlin` and `compileTestKotlin` tasks.

This PR removes the wrong comment on #2 and moves the code to the test file to show that it's working properly.