### PR TITLE
Relocate source code

### DIFF
--- a/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
+++ b/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
@@ -1,0 +1,8 @@
+// TODO: It doesn't support a composite package
+package singlepackage
+
+import arrow.*
+
+fun <A> given(evidence: @Given A = arrow.given): A = evidence
+@Given val x = "yes!"
+val result = given<String>()

--- a/src/test/kotlin/arrow/proofs/typeclasses/GivenTests.kt
+++ b/src/test/kotlin/arrow/proofs/typeclasses/GivenTests.kt
@@ -4,10 +4,6 @@ package singlepackage
 import arrow.*
 import org.junit.Test
 
-fun <A> given(evidence: @Given A = arrow.given): A = evidence
-@Given val x = "yes!"
-val result = given<String>()
-
 class GivenTest {
 
     @Test


### PR DESCRIPTION
To solve this error:

```
e: java.lang.IllegalStateException: Symbol for @arrow.Given public val x: kotlin.String defined in test[DeserializedPropertyDescriptor@7a3be316] is unbound
	at org.jetbrains.kotlin.ir.symbols.impl.IrBindableSymbolBase.getOwner(IrSymbolBase.kt:43)
	at arrow.meta.phases.codegen.ir.IrUtils.irCall(IrUtils.kt:54)
```