### PR TITLE
Add Kotlin EAP repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
+        maven { url "https://dl.bintray.com/kotlin/kotlin-eap/" }
     }
     dependencies {
         classpath "io.arrow-kt:gradle-plugin:$ARROW_META_VERSION"
@@ -21,6 +22,7 @@ sourceCompatibility = 1.8
 repositories {
     mavenLocal()
     mavenCentral()
+    maven { url "https://dl.bintray.com/kotlin/kotlin-eap/" }
 }
 
 dependencies {


### PR DESCRIPTION
To solve this error when running tests:

```
junit.framework.AssertionFailedError: Import failed: Could not find org.jetbrains.kotlin:kotlin-stdlib:1.4-M3.
Searched in the following locations:
  - file:/home/rachel/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib/1.4-M3/kotlin-stdlib-1.4-M3.pom
  - file:/home/rachel/.m2/repository/org/jetbrains/kotlin/kotlin-stdlib/1.4-M3/kotlin-stdlib-1.4-M3.jar
  - https://plugins.gradle.org/m2/org/jetbrains/kotlin/kotlin-stdlib/1.4-M3/kotlin-stdlib-1.4-M3.pom
Required by:
    project : > io.arrow-kt:gradle-plugin:1.3.61-SNAPSHOT
```