### PR TITLE
fix resolution

### DIFF
--- a/src/main/kotlin/arrow/proofs/demo/typeproofs/given.kt
+++ b/src/main/kotlin/arrow/proofs/demo/typeproofs/given.kt
@@ -5,7 +5,7 @@ import arrow.given
 
 //providers
 @Given
-val y: Int = 47
+internal val y: Int = 47
 
 @Given
 fun givenFun(): Unit = TODO()

--- a/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
+++ b/src/main/kotlin/arrow/proofs/typeclasses/Given.kt
@@ -6,6 +6,6 @@ import arrow.Given
 fun <A> given(evidence: @Given A = arrow.given): A = evidence
 
 @Given
-val x: String = "yes!"
+internal val x: String = "yes!"
 
 val result = given<String>()


### PR DESCRIPTION
for the PR https://github.com/arrow-kt/arrow-meta/pull/683
the current project fails with:
```
e: /private/var/folders/qq/0zkljkj12jb9m0jnwftykyd00000gn/T/unitTest_gradleProject_0__with_Gradle_5_6_4_1/tmp/GradleProject_0__with_Gradle_5_6_4_/project/arrow-typeproofs/src/main/kotlin/arrow/proofs/demo/typeproofs/given.kt: (7, 1): This GivenProof test.y on the type kotlin.Int violates ownership rules, because public Proofs over 3rd party Types break coherence over the kotlin ecosystem. One way to solve this is to declare the Proof as an internal orphan.
e: /private/var/folders/qq/0zkljkj12jb9m0jnwftykyd00000gn/T/unitTest_gradleProject_0__with_Gradle_5_6_4_1/tmp/GradleProject_0__with_Gradle_5_6_4_/project/arrow-typeproofs/src/main/kotlin/arrow/proofs/typeclasses/Given.kt: (8, 1): This GivenProof singlepackage.x on the type kotlin.String violates ownership rules, because public Proofs over 3rd party Types break coherence over the kotlin ecosystem. One way to solve this is to declare the Proof as an internal orphan.
:compileKotlin (Thread[Execution worker for ':' Thread 3,5,main]) completed. Took 12.057 secs.

FAILURE: Build failed with an exception.
```
